### PR TITLE
Remove JS audit job in audit workflow

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -25,22 +25,3 @@ jobs:
 
       - name: Run cargo-deny
         run: cargo-deny check
-
-  js:
-    name: Audit JS Dependencies
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Install Node toolchain
-        uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
-
-      - name: Install Nodejs toolchain
-        run: yarn install --frozen-lockfile
-
-      - name: Yarn audit
-        run: yarn audit


### PR DESCRIPTION
There is no JS in boba