### PR TITLE
Add encode benchmarks to compare boba with bubblebabble crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,6 @@ std = ["bstr/std"]
 bstr = { version = "0.2", default-features = false }
 
 [dev-dependencies]
+bubblebabble = "0.1"
 doc-comment = "0.3"
 version-sync = "0.8"

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -17,6 +17,11 @@ mod encode {
     fn benchmark_encode_vector_pineapple(b: &mut ::test::Bencher) {
         b.iter(|| boba::encode("Pineapple"))
     }
+
+    #[bench]
+    fn benchmark_encode_emoji(b: &mut ::test::Bencher) {
+        b.iter(|| boba::encode("💎🦀❤️✨💪"))
+    }
 }
 
 mod decode {

--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -17,4 +17,9 @@ mod encode {
     fn benchmark_encode_vector_pineapple(b: &mut ::test::Bencher) {
         b.iter(|| bubblebabble::bubblebabble(b"Pineapple"))
     }
+
+    #[bench]
+    fn benchmark_encode_emoji(b: &mut ::test::Bencher) {
+        b.iter(|| bubblebabble::bubblebabble("💎🦀❤️✨💪".as_bytes()))
+    }
 }

--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -1,0 +1,20 @@
+#![feature(test)]
+
+extern crate test;
+
+mod encode {
+    #[bench]
+    fn benchmark_encode_empty(b: &mut ::test::Bencher) {
+        b.iter(|| bubblebabble::bubblebabble(&[]))
+    }
+
+    #[bench]
+    fn benchmark_encode_vector_1234567890(b: &mut ::test::Bencher) {
+        b.iter(|| bubblebabble::bubblebabble(b"1234567890"))
+    }
+
+    #[bench]
+    fn benchmark_encode_vector_pineapple(b: &mut ::test::Bencher) {
+        b.iter(|| bubblebabble::bubblebabble(b"Pineapple"))
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -7,7 +7,8 @@ ignore = []
 [licenses]
 unlicensed = "deny"
 allow = [
-  "MIT"
+  "BSD-2-Clause",
+  "MIT",
 ]
 deny = []
 copyleft = "deny"


### PR DESCRIPTION
Comparison benchmarks: https://crates.io/crates/bubblebabble

This PR adds an additional encoding benchmark for an all emoji string.

`boba::encode` is between 15% and 20% faster than `bubblebabble::bubblebabble`.