### PR TITLE
Remove actions/setup-node build step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,10 +82,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Node toolchain
-        uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
+      - name: Format with prettier
+        run: npx prettier --check '**/*'
 
       - name: Format markdown with prettier
         run: npx prettier --prose-wrap always --check '**/*.md' '*.md'

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,16 @@
+**/*
+
+!**/*/
+
+node_modules/
+target/
+
+!*.html
+!*.js
+!*.json
+!*.md
+!*.yaml
+!*.yml
+
+**/vendor/*
+!**/vendor/*.md


### PR DESCRIPTION
This step has been flaky and it is not necessary because
the GitHub Actions base image ships with node 12.x.

Remove JS audit build.
run prettier with npx for formatting text.
Add prettier ignore and format all text sources, not just markdown.