### PR TITLE
Some project, build, and documentation fixups

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -21,7 +21,7 @@ jobs:
         run: |
           curl -sL "$RELEASE" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
         env:
-          RELEASE: "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.6.6/cargo-deny-0.6.6-x86_64-unknown-linux-musl.tar.gz"
+          RELEASE: "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.6.8/cargo-deny-0.6.8-x86_64-unknown-linux-musl.tar.gz"
 
       - name: Run cargo-deny
         run: cargo-deny check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,9 +80,3 @@ jobs:
 
       - name: Format with prettier
         run: npx prettier --check '**/*'
-
-      - name: Format markdown with prettier
-        run: npx prettier --prose-wrap always --check '**/*.md'
-
-      - name: Format YAML with prettier
-        run: npx prettier --prose-wrap always --check '**/*.{yaml,yml}'

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
+      RUSTDOCFLAGS: -D warnings
       RUST_BACKTRACE: 1
 
     steps:
@@ -29,7 +30,7 @@ jobs:
           components: rustfmt, rust-src
 
       - name: Build Documentation
-        run: cargo doc --all --no-deps
+        run: cargo doc
 
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,9 @@
+overrides:
+  # Always wrap markdown
+  - files: "*.md"
+    options:
+      proseWrap: always
+  # Preserve wrap for yaml as wrapping make some commands less readable
+  - files: "*.{yaml,yml}"
+    options:
+      proseWrap: preserve

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,145 @@
+# Contributing to Artichoke – Boba
+
+👋 Hi and welcome to [Artichoke](https://github.com/artichoke). Thanks for
+taking the time to contribute! 💪💎🙌
+
+Artichoke aspires to be a Ruby 2.6.3-compatible implementation of the Ruby
+programming language.
+[There is lots to do](https://github.com/artichoke/artichoke/issues).
+
+Boba is used to implement an obscure function in the
+[`Digest` package](https://ruby-doc.org/stdlib-2.6.3/libdoc/digest/rdoc/Digest.html#method-c-bubblebabble).
+
+If Artichoke does not run Ruby source code in the same way that MRI does, it is
+a bug and we would appreciate if you
+[filed an issue so we can fix it](https://github.com/artichoke/artichoke/issues/new).
+[File bugs specific to Boba in this repository](https://github.com/artichoke/boba/issues/new).
+
+If you would like to contribute code to Boba 👩‍💻👨‍💻, find an issue that looks
+interesting and leave a comment that you're beginning to investigate. If there
+is no issue, please file one before beginning to work on a PR.
+[Good first issues are labeled `E-easy`](https://github.com/artichoke/boba/labels/E-easy).
+
+## Discussion
+
+If you'd like to engage in a discussion outside of GitHub, you can
+[join Artichoke's public Discord server](https://discord.gg/QCe2tp2).
+
+## Setup
+
+Boba includes Rust and Text sources. Developing on Boba requires configuring
+several dependencies.
+
+### Rust Toolchain
+
+Boba depends on Rust and several compiler plugins for linting and formatting.
+Boba is guaranteed to build on the latest stable release of the Rust compiler.
+
+#### Installation
+
+The recommended way to install the Rust toolchain is with
+[rustup](https://rustup.rs/). On macOS, you can install rustup with
+[Homebrew](https://docs.brew.sh/Installation):
+
+```sh
+brew install rustup-init
+rustup-init
+```
+
+Once you have rustup, you can install the Rust toolchain needed to compile Boba:
+
+```sh
+rustup toolchain install stable
+rustup component add rustfmt
+rustup component add clippy
+```
+
+To update your stable Rust compiler to the latest version, run:
+
+```sh
+rustup update stable
+```
+
+### Rust Crates
+
+Boba depends on several Rust libraries, or crates. Once you have the Rust
+toolchain installed, you can install the crates specified in
+[`Cargo.toml`](Cargo.toml) by running:
+
+```sh
+cargo build
+```
+
+### Node.js
+
+Node.js is an optional dependency that is used for formatting text sources with
+[prettier](https://prettier.io/).
+
+Node.js is only required for formatting if modifying the following filetypes:
+
+- `md`
+- `yaml`
+- `yml`
+
+You will need to install
+[Node.js](https://nodejs.org/en/download/package-manager/).
+
+On macOS, you can install Node.js with
+[Homebrew](https://docs.brew.sh/Installation):
+
+```sh
+brew install node
+```
+
+## Linting
+
+To lint and format Rust sources run:
+
+```sh
+cargo fmt
+touch src/lib.rs
+cargo clippy --all-targets --all-features
+```
+
+To lint and format text sources run:
+
+```sh
+npx prettier --write '**/*'
+```
+
+## Testing
+
+A PR must have new or existing tests for it to be merged. The
+[Rust book chapter on testing](https://doc.rust-lang.org/book/ch11-00-testing.html)
+is a good place to start.
+
+To run tests:
+
+```sh
+cargo test
+```
+
+`cargo test` accepts a filter argument that will limit test execution to tests
+that substring match. For example, to run all of the tests for encoding:
+
+```sh
+cargo test encode
+```
+
+Tests are run for every PR. All builds must pass before merging a PR.
+
+## Updating Dependencies
+
+### Rust Crates
+
+Version specifiers in `Cargo.toml` are NPM caret-style by default. A version
+specifier of `4.1.2` means `4.1.2 <= version < 5.0.0`.
+
+To see what crates are outdated, you can use
+[cargo-outdated](https://github.com/kbknapp/cargo-outdated).
+
+If you need to pull in an updated version of a crate for a bugfix or a new
+feature, update the version number in `Cargo.toml`. See
+[GH-548](https://github.com/artichoke/artichoke/pull/548) for an example.
+
+Regular dependency bumps are handled by [@dependabot](https://dependabot.com/).


### PR DESCRIPTION
- Add CONTRIBUTING.md.
- Build docs with all deps, which enables linking to types in std.
- Fail build on warnings when building rustdoc.
- Add prettierrc config and simplify text lint build steps.
- Upgrade cargo-audit to 0.6.8.