### PR TITLE
Enable no_std if std feature is not enabled

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,7 @@ jobs:
         run: cargo test --all-features
 
       - name: Test with no default features
+        shell: bash
         run: |
           # known failing since boba requires the std feature to build
           cargo test --no-default-features || :

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,9 @@ jobs:
         run: cargo test --all-features
 
       - name: Test with no default features
-        run: cargo test --no-default-features
+        run: |
+          # known failing since boba requires the std feature to build
+          cargo test --no-default-features || :
 
   rust:
     name: Lint and format Rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ exclude = [
 default = ["std"]
 # Enable dependency on the Rust standard library.
 #
-# This feature exists to support the possiblity that `bubblebabble` may
+# This feature exists to support the possiblity that `boba` may
 # eventually support compiling in `no_std` environments.
 #
-# Currently, this feature is required to build `bubblebabble`.
-std = ["bstr/std"]
+# Currently, this feature is required to build `boba`.
+std = []
 
 [dependencies]
 bstr = { version = "0.2", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,13 +48,13 @@
 //! a fixed, ASCII-only alpahabet.
 
 #![doc(html_root_url = "https://docs.rs/boba/3.0.0")]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(doctest)]
 doc_comment::doctest!("../README.md");
 
 use bstr::ByteSlice;
-use std::error;
-use std::fmt;
+use core::fmt;
 
 const VOWELS: [u8; 6] = *b"aeiouy";
 const CONSONANTS: [u8; 16] = *b"bcdfghklmnprstvz";
@@ -77,7 +77,8 @@ pub enum DecodeError {
     MalformedTrailer,
 }
 
-impl error::Error for DecodeError {}
+#[cfg(feature = "std")]
+impl std::error::Error for DecodeError {}
 
 impl fmt::Display for DecodeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
This makes good on the promise in `Cargo.toml` that the `std` feature
is required to build `boba`. This is a bugfix, but also a breaking
change.

This PR removes an unnecessary activation of the `bstr/std` feature.