### PR TITLE
Run cargo-diet to minimize includes for packaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,10 @@ homepage = "https://github.com/artichoke/boba"
 description = "Encoder and decoder for the Bubble Babble binary data encoding"
 keywords = ["encode", "decode", "utf8", "bubblebabble"]
 categories = ["encoding"]
-exclude = [
-  ".github",
-  ".gitignore",
-  "deny.toml",
-  "fuzz",
+include = [
+  "src/**/*.rs",
+  "LICENSE",
+  "README.md",
 ]
 
 [features]


### PR DESCRIPTION
This makes the `.crate` package as light as possible.