### PR TITLE
Add Zlib to license allowlist in deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,7 @@ unlicensed = "deny"
 allow = [
   "BSD-2-Clause",
   "MIT",
+  "Zlib",
 ]
 deny = []
 copyleft = "deny"


### PR DESCRIPTION
version-sync transitively depends on tinyvec.