### PR TITLE
Replace doc_comment dev-dependency with a small inlined macro_rules macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,4 @@ bstr = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 bubblebabble = "0.1"
-doc-comment = "0.3"
 version-sync = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,19 @@
 // without the `std` feature, build `boba` with `no_std`.
 #![cfg_attr(not(feature = "std"), no_std)]
 
+// Ensure code blocks in README.md compile
 #[cfg(doctest)]
-doc_comment::doctest!("../README.md");
+macro_rules! readme {
+    ($x:expr) => {
+        #[doc = $x]
+        mod readme {}
+    };
+    () => {
+        readme!(include_str!("../README.md"));
+    };
+}
+#[cfg(doctest)]
+readme!();
 
 use bstr::ByteSlice;
 use core::fmt;


### PR DESCRIPTION
Remove a dev dep and avoid upgrading to doc-comment 0.4 based on proc-macros.